### PR TITLE
Fix Kubernetes kernel ID env var bug

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -269,7 +269,7 @@ class RemoteMappingKernelManager(AsyncMappingKernelManager):
     def new_kernel_id(self, **kwargs):
         """Determines the kernel_id to use for a new kernel."""
 
-        return new_kernel_id(kernel_id_fn=super(RemoteMappingKernelManager, self).new_kernel_id, log=self.log)
+        return new_kernel_id(kernel_id_fn=super(RemoteMappingKernelManager, self).new_kernel_id, log=self.log, **kwargs)
 
 
 class RemoteKernelManager(EnterpriseGatewayConfigMixin, AsyncIOLoopKernelManager):


### PR DESCRIPTION
Steps to reproduce:
1. Deploy enterprise gateway to Kubernetes cluster.
2. Create new kernel with a provided `KERNEL_ID` env var:

```bash
curl -i -X POST -d'{"name": "python_kubernetes", "env":{"KERNEL_ID": "1884ef38-9742-4322-a62d-004f57b1c36d"}}' http://192.168.99.108:30418/api/kernels

HTTP/1.1 201 Created
Server: TornadoServer/6.0.4
Content-Type: application/json
Date: Thu, 17 Sep 2020 07:36:34 GMT
X-Content-Type-Options: nosniff
Location: /api/kernels/d5294503-b97d-480a-afe2-8e14be1f7735
Content-Length: 172

{"id": "d5294503-b97d-480a-afe2-8e14be1f7735", "name": "python_kubernetes", "last_activity": "2020-09-17T07:36:37.819687Z", "execution_state": "starting", "connections": 0}
```

Kernel should be created with the ID value provided (`1884ef38-9742-4322-a62d-004f57b1c36d`), but the value is ignored and random one (`d5294503-b97d-480a-afe2-8e14be1f7735`) is generated.